### PR TITLE
fix: relax aiohttp constraint for Home Assistant compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyIntradel"
-version = "0.0.5"
+version = "0.0.6"
 description = "Python interface for Intradel"
 readme = "README.md"
 license = { text = "MIT" }
@@ -13,7 +13,7 @@ authors = [
     { name = "Thomas Germain", email = "12560542+thomasgermain@users.noreply.github.com" },
 ]
 dependencies = [
-    "aiohttp>=3.14,<4.0",
+    "aiohttp>=3.11,<4.0",
     "beautifulsoup4>=4.15,<5.0",
 ]
 classifiers = [


### PR DESCRIPTION
HA pins aiohttp to an exact version via its constraints file (2026.6 -> aiohttp==3.13.5, 2025.1 -> 3.11.11). The previous >=3.14 floor made the manifest requirement unsatisfiable under HA's constraints, so the HA integration failed to install. Lower the floor to >=3.11,<4.0.